### PR TITLE
[Fix] ScrapAnswer Null Point Exception

### DIFF
--- a/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
+++ b/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
@@ -34,9 +34,8 @@ public class ScrapAnswer {
 	private LocalDateTime updatedAt;
 
 	private void setContent(String content) {
-		if (content.getBytes(StandardCharsets.UTF_8).length > 100000) {
+		if (!content.isEmpty() && content.getBytes(StandardCharsets.UTF_8).length > 100000) {
 			throw new IbValidationException("Scrap Answer content over 100000 byte");
 		}
-
 	}
 }

--- a/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
+++ b/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
@@ -37,6 +37,5 @@ public class ScrapAnswer {
 		if (!content.isEmpty() && content.getBytes(StandardCharsets.UTF_8).length > 100000) {
 			throw new IbValidationException("Scrap Answer content over 100000 byte");
 		}
-
 	}
 }

--- a/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
+++ b/src/main/java/org/hoongoin/interviewbank/scrap/application/entity/ScrapAnswer.java
@@ -37,5 +37,6 @@ public class ScrapAnswer {
 		if (!content.isEmpty() && content.getBytes(StandardCharsets.UTF_8).length > 100000) {
 			throw new IbValidationException("Scrap Answer content over 100000 byte");
 		}
+
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위
---
- #26 
- ScrapAnswer validation시 content null도 가능하도록 수정
