### PR TITLE
[Fix] swap job category level

### DIFF
--- a/src/main/java/org/hoongoin/interviewbank/interview/infrastructure/repository/JobCategoryRepository.java
+++ b/src/main/java/org/hoongoin/interviewbank/interview/infrastructure/repository/JobCategoryRepository.java
@@ -27,7 +27,9 @@ public interface JobCategoryRepository extends JpaRepository<JobCategoryEntity, 
 		"WHERE firstLevel.parentJobCategory IS NULL")
 	List<JobCategoryWithHierarchy> findAllJobCategoriesWithHierarchy();
 
-	@Query("SELECT new org.hoongoin.interviewbank.interview.application.entity.JobCategory(jc.id, pjc.name, jc.name) " +
+	@Query("SELECT new org.hoongoin.interviewbank.interview.application.entity.JobCategory(jc.id, " +
+		"COALESCE(pjc.name, jc.name), " +
+		"CASE WHEN pjc.name IS NULL THEN NULL ELSE jc.name END) " +
 		"FROM JobCategoryEntity jc " +
 		"LEFT JOIN jc.parentJobCategory pjc " +
 		"WHERE jc.id = :job_category_id")


### PR DESCRIPTION
## ✅  작업 단위
---
- #112 
- second job category가 null알 때 first level name과 second level name이 반대로 나오는 오류 해결
