### PR TITLE
[Fix] scrap read detail auth

### DIFF
--- a/src/main/java/org/hoongoin/interviewbank/config/SecurityConfig.java
+++ b/src/main/java/org/hoongoin/interviewbank/config/SecurityConfig.java
@@ -19,10 +19,9 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.authorizeRequests()
-			.antMatchers("/account/logout").authenticated()
-			.antMatchers("/account/me").authenticated()
-			.antMatchers("/account/reset-password").authenticated()
+			.antMatchers("/account/logout", "/account/me", "/account/reset-password").authenticated()
 			.antMatchers("/account/**").permitAll()
+			.antMatchers(HttpMethod.GET, "/scraps/{scrap-id}").permitAll()
 			.antMatchers("/scraps/**").authenticated()
 			.antMatchers("/").permitAll()
 			.antMatchers(HttpMethod.POST, "/interview").authenticated()

--- a/src/main/java/org/hoongoin/interviewbank/scrap/application/ScrapService.java
+++ b/src/main/java/org/hoongoin/interviewbank/scrap/application/ScrapService.java
@@ -64,7 +64,7 @@ public class ScrapService {
 		Scrap scrap = Scrap.builder()
 			.interviewId(originalInterview.getInterviewId())
 			.title(originalInterview.getTitle())
-				.isPublic(false)
+			.isPublic(false)
 			.jobCategoryId(originalInterview.getJobCategoryId())
 			.build();
 
@@ -109,7 +109,9 @@ public class ScrapService {
 	@Transactional(readOnly = true)
 	public ReadScrapDetailResponse readScrapDetailById(long scrapId, long requestingAccountId) {
 		Scrap scrap = scrapQueryService.findScrapByScrapId(scrapId);
-		checkScrapAuthority(scrap.getAccountId(), requestingAccountId);
+		if (!scrap.getIsPublic()) {
+			checkScrapAuthority(scrap.getAccountId(), requestingAccountId);
+		}
 
 		Interview interview = interviewQueryService.findInterviewById(scrap.getInterviewId());
 
@@ -146,7 +148,7 @@ public class ScrapService {
 		);
 
 		return new ReadScrapPageResponse(scrapPageDto.getTotalPages(), scrapPageDto.getTotalElements(),
-				scrapPageDto.getCurrentPage(), scrapPageDto.getCurrentElements(), readScrapPageResponseScraps);
+			scrapPageDto.getCurrentPage(), scrapPageDto.getCurrentElements(), readScrapPageResponseScraps);
 	}
 
 	@Transactional
@@ -185,7 +187,8 @@ public class ScrapService {
 
 	private ReadScrapDetailResponse makeReadScrapResponse(Scrap scrap, Interview interview,
 		List<ScrapQuestionWithScrapAnswers> scrapQuestionsWithScrapAnswers) {
-		ReadScrapDetailResponse.ScrapResponse scrapResponse = scrapMapper.scrapToReadScrapDetailResponseOfScrapResponse(scrap);
+		ReadScrapDetailResponse.ScrapResponse scrapResponse = scrapMapper.scrapToReadScrapDetailResponseOfScrapResponse(
+			scrap);
 		ReadScrapDetailResponse.OriginalInterviewResponse interviewResponse = new ReadScrapDetailResponse.OriginalInterviewResponse(
 			interview.getInterviewId(), interview.getTitle());
 

--- a/src/test/java/org/hoongoin/interviewbank/authentication/ScrapApiAuthentication.java
+++ b/src/test/java/org/hoongoin/interviewbank/authentication/ScrapApiAuthentication.java
@@ -64,9 +64,9 @@ class ScrapApiAuthentication {
 
 	@WithAnonymousUser
 	@Test
-	void readScrapDetail_Fail_Unauthorized() throws Exception {
+	void readScrapDetail_Success_WithAnonymousUser() throws Exception {
 		mockMvc.perform(get("/scraps/3"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().isOk());
 	}
 
 	@IbWithMockUser

--- a/src/test/java/org/hoongoin/interviewbank/scrap/application/ScrapServiceTest.java
+++ b/src/test/java/org/hoongoin/interviewbank/scrap/application/ScrapServiceTest.java
@@ -6,9 +6,9 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
+import org.hoongoin.interviewbank.exception.IbBadRequestException;
 import org.hoongoin.interviewbank.interview.InterviewTestFactory;
 import org.hoongoin.interviewbank.interview.application.entity.Interview;
 import org.hoongoin.interviewbank.interview.domain.InterviewQueryService;
@@ -122,5 +122,23 @@ class ScrapServiceTest {
 		assertThat(response.getOriginalInterview().getInterviewId()).isEqualTo(interview.getInterviewId());
 		assertThat(response.getScrapQuestionWithScrapAnswersList().get(0)).isEqualTo(
 			scrapQuestionWithScrapAnswersResponses.get(0));
+	}
+
+	@Test
+	void readScrapDetailById_Fail_WhenReadingPrivateScrapOfAnotherUser(){
+		// given
+		long scrapId = 1L;
+		long scrapWriterAccountId = 1L;
+		long requestingAccountId = 2L;
+
+		Scrap scrap = ScrapTestFactory.createScrap();
+
+		given(scrapQueryService.findScrapByScrapId(scrapId)).willReturn(scrap);
+
+		// when //then
+		assertThatThrownBy(() -> {
+			scrapService.readScrapDetailById(scrapId, requestingAccountId);
+		}).isInstanceOf(IbBadRequestException.class)
+			.hasMessage("Bad Request");
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위
---
- #221 
- Scrap에 Public/Private 을 추가함에 따라, read scrap detail의 security 권한을 permitAll()로 낮추고, private일 경우 다른 유저가 보지 못하도록 서비스 로직 수정
- private인 scrap을 다른 유저가 접근하려할 때 실패하는 테스트 코드 작성
